### PR TITLE
renamed multi_select to multiselect

### DIFF
--- a/explorer/menu.py
+++ b/explorer/menu.py
@@ -30,7 +30,7 @@ def menu(path, suffix_list):
         options = list
         options.append(">back<")
         options.append(">quit<")
-        selected = pick(options, title, multi_select=True, min_selection_count=1)
+        selected = pick(options, title, multiselect=True, min_selection_count=1)
         selected_deal(selected, list, suffix_list, path)
     else:
         print("The path is invaild!")


### PR DESCRIPTION
FIXED: TypeError: Picker.__init__() got an unexpected keyword argument 'multi_select'